### PR TITLE
ADM remediating 6 vulnerable artifacts

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.10</version>
+			<version>1.21</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>23.2-jre</version>
+				<version>32.0.0-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>org.projectlombok</groupId>
@@ -144,7 +144,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.5</version>
+				<version>2.8.9</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>

--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.0.5</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.4</version>
+			<version>3.5</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.phx.amaaaaaa5f5ialyadc7wrqkpd3jhejtz25oae7gtxk22lcliwqpz5stadr3q/runs/ocid1.admremediationrun.oc1.phx.amaaaaaa5f5ialyappidreksdothoorpdutzoul6xoedm55v2ruih54xj46q/stages/DETECT)

* net.runelite:cache:1.10.11-SNAPSHOT
  * com.google.code.gson:gson:2.8.5
    * CVE-2022-25647
  * com.google.guava:guava:23.2-jre
    * CVE-2018-10237
    * CVE-2020-8908
    * CVE-2023-2976
  * org.apache.commons:commons-compress:1.10
    * CVE-2018-11771
    * CVE-2021-35515
    * CVE-2021-35516
    * CVE-2021-35517
    * CVE-2021-36090
* net.runelite:client:1.10.11-SNAPSHOT
  * com.google.code.gson:gson:2.8.5
    * CVE-2022-25647
  * com.google.guava:guava:23.2-jre
    * CVE-2018-10237
    * CVE-2020-8908
    * CVE-2023-2976
  * com.google.inject:guice:4.1.0
    * com.google.guava:guava:23.2-jre
      * CVE-2018-10237
      * CVE-2020-8908
      * CVE-2023-2976
  * net.runelite.arn:http-api:1.2.6
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.squareup.okio:okio:1.17.2
      * CVE-2023-3635
  * net.runelite:jshell:1.10.11-SNAPSHOT
    * com.google.guava:guava:23.2-jre
      * CVE-2018-10237
      * CVE-2020-8908
      * CVE-2023-2976
* net.runelite:jshell:1.10.11-SNAPSHOT
  * com.google.inject:guice:4.1.0
    * com.google.guava:guava:23.2-jre
      * CVE-2018-10237
      * CVE-2020-8908
      * CVE-2023-2976
* net.runelite:script-assembler-plugin:1.10.11-SNAPSHOT
  * net.runelite:cache:1.10.11-SNAPSHOT
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:23.2-jre
      * CVE-2018-10237
      * CVE-2020-8908
      * CVE-2023-2976
    * org.apache.commons:commons-compress:1.10
      * CVE-2018-11771
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.maven.plugin-tools:maven-plugin-annotations:3.4
    * org.codehaus.plexus:plexus-utils:2.0.6
      * CVE-2017-1000487
  * org.apache.maven:maven-plugin-api:3.0.5
    * org.codehaus.plexus:plexus-utils:2.0.6
      * CVE-2017-1000487

## Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.phx.amaaaaaa5f5ialyadc7wrqkpd3jhejtz25oae7gtxk22lcliwqpz5stadr3q/runs/ocid1.admremediationrun.oc1.phx.amaaaaaa5f5ialyappidreksdothoorpdutzoul6xoedm55v2ruih54xj46q/stages/RECOMMEND)

* com.google.code.gson:gson:2.8.5 -> 2.8.9
* com.google.guava:guava:23.2-jre -> 32.0.0-jre
* com.google.guava:guava:23.2-jre -> 32.0.0-jre
* org.apache.commons:commons-compress:1.10 -> 1.21
* org.apache.maven.plugin-tools:maven-plugin-annotations:3.4 -> 3.5
* org.apache.maven:maven-plugin-api:3.0.5 -> 3.2.1

Auto-merge is disabled.